### PR TITLE
Updates siteUrl in config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = {
     title: 'Open data, design, & development at the Department of the Interior',
     author: 'Ryan Johnson',
     description: 'Our blog about data, design, and innovation at the Department of the Interior',
-    siteUrl: 'https://revenuedata.doi.gov/',
+    siteUrl: 'https://blog-nrrd.doi.gov/',
   },
   pathPrefix: `${BASEURL}/`,
   mapping: {


### PR DESCRIPTION
- Corrects the `siteUrl` field in `gatsbyconfig.js`
- Corrects metadata carryover from previous implementation
- Enables #315 to work as expected